### PR TITLE
ci: add validation and release workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,20 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  validate:
+    name: Validate WIT
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Install wasm-tools
+        uses: bytecodealliance/actions/wasm-tools/setup@v1
+
+      - name: Validate WIT
+        run: wasm-tools component wit wit/

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -1,0 +1,55 @@
+name: Prepare Release
+
+on:
+  workflow_dispatch:
+
+jobs:
+  prepare:
+    name: Create Release PR
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Determine next RC version
+        id: version
+        run: |
+          # Find highest RC number from existing tags
+          HIGHEST_RC=0
+          for tag in $(git tag -l 'v0.2.0-rc.*'); do
+            if [[ "$tag" =~ ^v0\.2\.0-rc\.([0-9]+)$ ]]; then
+              RC_NUM="${BASH_REMATCH[1]}"
+              if [ "$RC_NUM" -gt "$HIGHEST_RC" ]; then
+                HIGHEST_RC="$RC_NUM"
+              fi
+            fi
+          done
+
+          NEXT_RC=$((HIGHEST_RC + 1))
+          VERSION="0.2.0-rc.${NEXT_RC}"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Preparing version: $VERSION"
+
+      - name: Bump package version
+        run: |
+          # Update package version (matches wasi:otel@ANY_VERSION)
+          find wit -type f -name "*.wit" -exec sed -i \
+            "s/\(wasi:otel@\)[^;]*/\1${{ steps.version.outputs.version }}/g" {} +
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@5e914681df9dc83aa4e4905692ca88beb2f9e91f # v7.0.5
+        with:
+          commit-message: "chore: bump version to ${{ steps.version.outputs.version }}"
+          branch: release/${{ steps.version.outputs.version }}
+          title: "Release ${{ steps.version.outputs.version }}"
+          body: |
+            Bumps package version to `${{ steps.version.outputs.version }}`.
+
+            Once merged, manually run the **Publish Release** workflow to:
+            - Create git tag `v${{ steps.version.outputs.version }}`
+            - Create GitHub release
+            - Publish to `ghcr.io/webassembly/wasi/otel:${{ steps.version.outputs.version }}`

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -1,0 +1,95 @@
+name: Publish Release
+
+on:
+  workflow_dispatch:
+
+jobs:
+  publish:
+    name: Publish Release
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      packages: write
+      contents: write
+      attestations: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Extract version from package
+        id: version
+        run: |
+          # Extract version from wit/world.wit
+          VERSION=$(grep -oP 'package wasi:otel@\K[^;]+' wit/world.wit)
+          if [[ ! "$VERSION" =~ ^0\.2\.0-rc\.[0-9]+$ ]]; then
+            echo "Error: Version '$VERSION' is not a valid RC version"
+            exit 1
+          fi
+          TAG="v${VERSION}"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "Publishing version: $VERSION"
+
+      - name: Check tag doesn't exist
+        run: |
+          if git tag -l "${{ steps.version.outputs.tag }}" | grep -q .; then
+            echo "Error: Tag ${{ steps.version.outputs.tag }} already exists"
+            exit 1
+          fi
+
+      - name: Create git tag
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag -a "${{ steps.version.outputs.tag }}" -m "Release ${{ steps.version.outputs.version }}"
+          git push origin "${{ steps.version.outputs.tag }}"
+
+      - name: Create GitHub release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "${{ steps.version.outputs.tag }}" \
+            --title "${{ steps.version.outputs.version }}" \
+            --prerelease \
+            --generate-notes
+
+      - name: Install cargo-binstall
+        uses: cargo-bins/cargo-binstall@80aaafe04903087c333980fa2686259ddd34b2d9 # v1.16.6
+
+      - name: Install wkg
+        run: cargo binstall -y "wkg@0.13.0"
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build WIT package
+        run: wkg wit build -o wasi-otel.wasm
+
+      - name: Publish to GitHub Container Registry
+        id: publish
+        uses: bytecodealliance/wkg-github-action@10b3b04b9059ba46208cd7daf7d352af14bded0f # v5
+        with:
+          oci-reference-without-tag: ghcr.io/webassembly/wasi/otel
+          file: wasi-otel.wasm
+          description: 'WASI OpenTelemetry API'
+          source: https://github.com/WebAssembly/wasi-otel
+          homepage: https://github.com/WebAssembly/wasi-otel
+          version: ${{ steps.version.outputs.version }}
+          licenses: Apache-2.0 WITH LLVM-exception
+
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@00014ed6ed5efc5b1ab7f7f34a39eb55d41aa4f8 # v3.1.0
+        with:
+          subject-name: ghcr.io/webassembly/wasi/otel
+          subject-digest: ${{ steps.publish.outputs.digest }}
+          push-to-registry: true
+
+      - name: Upload wasm to release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release upload "${{ steps.version.outputs.tag }}" wasi-otel.wasm


### PR DESCRIPTION
This pr adds GH Workflows.

Release Flow:

1. Run Prepare Release workflow
2. Review and merge the generated PR
3. Run Publish Release workflow

## CI (ci.yml)

- Validates WIT syntax on push/PR to main

## Prepare Release (prepare-release.yml)

- Manual trigger via workflow_dispatch
- Auto-increments RC version (e.g., 0.2.0-rc.1 → 0.2.0-rc.2)
- Creates PR with version bump in wit/world.wit

## Publish Release (publish-release.yml)

- Manual trigger after release PR is merged
- Creates git tag and GitHub release
- Publishes to ghcr.io/webassembly/wasi/otel
- Attests build provenance
