### PR TITLE
ci: upgrade create-pull-request to v8

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -41,7 +41,7 @@ jobs:
             "s/\(wasi:otel@\)[^;]*/\1${{ steps.version.outputs.version }}/g" {} +
 
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@5e914681df9dc83aa4e4905692ca88beb2f9e91f # v7.0.5
+        uses: peter-evans/create-pull-request@c0f553fe549906ede9cf27b5156039d195d2ece0 # v8.1.0
         with:
           commit-message: "chore: bump version to ${{ steps.version.outputs.version }}"
           branch: release/${{ steps.version.outputs.version }}


### PR DESCRIPTION
Upgrade peter-evans/create-pull-request from v7.0.5 to v8.0.0 which is needed for compatibility with actions/checkout v6.

See peter-evans/create-pull-request#4272

Fixes https://github.com/WebAssembly/wasi-otel/actions/runs/21490097376