### PR TITLE
doc: documenting how byte arrays are handled when converted to JSON

### DIFF
--- a/wit/types.wit
+++ b/wit/types.wit
@@ -14,6 +14,10 @@ interface types {
     ///
     /// This corresponds with the `AnyValue` type defined in the [attribute spec](https://opentelemetry.io/docs/specs/otel/common/#anyvalue).
     /// Because WIT doesn't support recursive types, the data needs to be serialized. JSON is used as the encoding format.
+    ///
+    /// Byte arrays require special encoding since JSON cannot distinguish them from number arrays.
+    /// They are base64-encoded with a prefix that follows the Data URI RFC 2397 convention: 
+    /// `data:application/octet-stream;base64,<BASE64_ENCODED_BYTES>`
     type value = string;
 
     /// An immutable representation of the entity producing telemetry as attributes.


### PR DESCRIPTION
See [opentelemtry-wasi](https://github.com/calebschoepp/opentelemetry-wasi/blob/ebd275fe947c485465ec99b4ea1e25715c286d42/rust/src/logs/conversion.rs#L64) for an example implementation. 