### PR TITLE
Replace `outer-span-context` with `current-span-context`

### DIFF
--- a/wit/tracing.wit
+++ b/wit/tracing.wit
@@ -8,7 +8,7 @@ interface tracing {
     /// Called when a span is ended.
     on-end: func(span: span-data);
 
-    /// Returns the currently active ambient span context
+    /// Returns the span context of the most recently entered span.
     current-span-context: func() -> span-context;
 
     /// The data associated with a span.

--- a/wit/tracing.wit
+++ b/wit/tracing.wit
@@ -8,8 +8,8 @@ interface tracing {
     /// Called when a span is ended.
     on-end: func(span: span-data);
 
-    /// Returns the span context of the host.
-    outer-span-context: func() -> span-context;
+    /// Returns the currently active ambient span context
+    current-span-context: func() -> span-context;
 
     /// The data associated with a span.
     record span-data {


### PR DESCRIPTION
Allows static compositions to preserve causal relationships between spans through ambient context (#15). 
Scenario: a static composition containing the `gateway` and `service` worlds, with the `service` satisfying `gateway` imports for business logic. Each function call starts a new span in the current trace.

**With `outer-span-context` for context propagation**

```
HTTP span (host)
 ├── `gateway` span // `outer-span-context` = HTTP span
 ├── `service` span // `outer-span-context` = HTTP span
```

Result: causal relationship between `gateway` and `service` is lost.

**With `current-span-context` for context propagation**

```
HTTP span (host)
 └── `gateway` span  // `current-span-context` = HTTP span
      └── `service` span // `current-span-context` = `gateway` span
```

Result: causal relationship between spans is preserved :100: